### PR TITLE
Support state reducer

### DIFF
--- a/packages/bootstrap/tests/Form.test.js
+++ b/packages/bootstrap/tests/Form.test.js
@@ -1585,6 +1585,48 @@ describe('Form', () => {
     });
   });
 
+  describe('reducer', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        foo: { title: 'Foo', type: 'string' },
+        bar: { title: 'Bar', type: 'string' }
+      }
+    };
+
+    it('should update internal state', () => {
+      const reducer = state => {
+        let formData = state.formData;
+
+        if (formData.foo === 'boo') {
+          formData = {
+            ...formData,
+            bar: 'bongo!'
+          };
+        }
+
+        return {
+          ...state,
+          formData
+        };
+      };
+
+      const { getInstance, getByLabelText } = createFormComponent({
+        schema,
+        reducer
+      });
+
+      fireEvent.change(getByLabelText('Foo'), { target: { value: 'b' } });
+      expect(getInstance().state.formData).toEqual({ foo: 'b' });
+
+      fireEvent.change(getByLabelText('Foo'), { target: { value: 'boo' } });
+      expect(getInstance().state.formData).toEqual({
+        foo: 'boo',
+        bar: 'bongo!'
+      });
+    });
+  });
+
   describe('Attributes', () => {
     const formProps = {
       schema: {},

--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -18,13 +18,14 @@ export default class Form extends PureComponent {
     noHtml5Validate: false
   };
 
-  state = getStateFromProps(this.props);
+  state = this.reducer(getStateFromProps(this.props));
 
   static getDerivedStateFromProps(props, state) {
     const keys = Object.keys(state.cachedProps);
     const changed = keys.some(key => props[key] !== state.cachedProps[key]);
     if (changed) {
-      return getStateFromProps(props, state);
+      const newState = getStateFromProps(props, state);
+      return props.reducer ? props.reducer(newState) : newState;
     }
     return null;
   }
@@ -62,6 +63,13 @@ export default class Form extends PureComponent {
     return null;
   }
 
+  reducer(newState) {
+    if (this.props.reducer) {
+      return this.props.reducer(newState);
+    }
+    return newState;
+  }
+
   onChange = (formData, newErrorSchema) => {
     const mustValidate = !this.props.noValidate && this.props.liveValidate;
     let state = { formData };
@@ -75,7 +83,7 @@ export default class Form extends PureComponent {
         errors: toErrorList(newErrorSchema)
       };
     }
-    setState(this, state, () => {
+    setState(this, this.reducer(state), () => {
       if (this.props.onChange) {
         this.props.onChange(this.state);
       }
@@ -276,6 +284,7 @@ if (process.env.NODE_ENV !== 'production') {
     validate: PropTypes.func,
     transformErrors: PropTypes.func,
     safeRenderCompletion: PropTypes.bool,
-    formContext: PropTypes.object
+    formContext: PropTypes.object,
+    reducer: PropTypes.func
   };
 }


### PR DESCRIPTION
### Reasons for making this change

If you change e.g. `schema` or `formData` outside of the `<Form>` then it goes through the relatively heavy procedure `getStateFromProps()`. But with this change is possible to interfere into the state change inside of the `<Form>` without calling `getStateFromProps()`. It's for advanced usecases (mainly performance gains).

#### __Warning__
It's __not meant for huge changes__ because __it skips the internal procedures__ required for building the form. But it's useful if you, for example, want to change only some value in keywords (minimum, maximum, ...):

```js
import produce from 'immer';

const schema = {
  type: 'object',
  properties: {
    selected: {
      title: 'Which case is the final?',
      type: 'number',
      minimum: '1',
      maximum: '1'
    },
    cases: {
      type: 'array',
      items: {
        type: 'object',
        properties: {}
      }
    }
  }
};

const reducer = produce(({ schema, formData }) => {
  if (schema.properties.selected.maximum !== formData.cases.length) {
    schema.properties.selected.maximum = formData.cases.length;
  }
});

<Form schema={schema} reducer={reducer} />;
```

Other usecase is for example evaluating derived values.

### Checklist

* [x] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
